### PR TITLE
Use question mark icon when HeroIcon doesn't exist

### DIFF
--- a/src/Blazor.Heroicons.Demo/Pages/Index.razor
+++ b/src/Blazor.Heroicons.Demo/Pages/Index.razor
@@ -87,6 +87,14 @@
                     &lt;RandomHeroicon Type="HeroiconType.Mini" /&gt;
                 </div>
             </div>
+            <div>
+                <div>
+                    <Heroicon Name="ThisIconDoesNotExist" class="h-10 w-10 mx-auto" />
+                </div>
+                <div class="bg-gray-100 rounded px-3 py-1 text-gray-800 text-xs mt-2 w-full">
+                    &lt;Heroicon Name="ThisIconDoesNotExist" /&gt;
+                </div>
+            </div>
         </div>
     </div>
 </main>

--- a/src/Blazor.Heroicons/Blazor.Heroicons.csproj
+++ b/src/Blazor.Heroicons/Blazor.Heroicons.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Version>1.2.4</Version>
+		<Version>1.2.3</Version>
 		<Authors>Tom McKnight</Authors>
 		<PackageProjectUrl>https://github.com/tmcknight/Blazor.Heroicons</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/tmcknight/Blazor.Heroicons</RepositoryUrl>

--- a/src/Blazor.Heroicons/Blazor.Heroicons.csproj
+++ b/src/Blazor.Heroicons/Blazor.Heroicons.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Version>1.2.3</Version>
+		<Version>1.2.4</Version>
 		<Authors>Tom McKnight</Authors>
 		<PackageProjectUrl>https://github.com/tmcknight/Blazor.Heroicons</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/tmcknight/Blazor.Heroicons</RepositoryUrl>

--- a/src/Blazor.Heroicons/Heroicon.razor
+++ b/src/Blazor.Heroicons/Heroicon.razor
@@ -37,8 +37,8 @@
             _heroiconType = Type;
         }
 
-        if (_razorComponentType is null)
-            throw new Exception($"Heroicon '{Type}.{name}' not found");
+        //if icon is not found, use question mark circle icon
+        _razorComponentType ??= typeof(Outline.QuestionMarkCircleIcon);
     }
 
 }


### PR DESCRIPTION
If an invalid icon name is used, show the question mark icon as opposed to throwing an exception.