### PR TITLE
Update target .NET frameworks

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,10 +16,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
             9.0.x
+            10.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
       - name: Restore dependencies
         run: dotnet restore src/Blazor.Heroicons/Blazor.Heroicons.csproj
       - name: Build

--- a/src/Blazor.Heroicons/Blazor.Heroicons.csproj
+++ b/src/Blazor.Heroicons/Blazor.Heroicons.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 	<PropertyGroup>
 		<PackageId>Blazor.Heroicons</PackageId>
-		<TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -25,12 +25,10 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web"
+						  Version="10.0.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web"
 						  Version="9.0.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" 
 						  Version="8.0.*" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web"
-						  Version="7.0.*" Condition="'$(TargetFramework)' == 'net7.0'" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" 
-						  Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
 	</ItemGroup>
 </Project>

--- a/tests/Blazor.Heroicons.Tests/Blazor.Heroicons.Tests.csproj
+++ b/tests/Blazor.Heroicons.Tests/Blazor.Heroicons.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This pull request updates the project to support .NET 10.0, removing support for .NET 6.0 and 7.0. It updates workflows and project files to ensure compatibility with the latest .NET versions.

.NET version support updates:

* Updated `TargetFrameworks` in both `Blazor.Heroicons.csproj` and `Blazor.Heroicons.Tests.csproj` to include `net10.0` and remove `net6.0` and `net7.0`. (`src/Blazor.Heroicons/Blazor.Heroicons.csproj` [[1]](diffhunk://#diff-093feab2d26d5191666c124bbb68a5e630c628adbacf3f5eb376470071ea78ffL4-R4) `tests/Blazor.Heroicons.Tests/Blazor.Heroicons.Tests.csproj` [[2]](diffhunk://#diff-2ef8a4081d4ec63fca1a6ec7fcb3a485ff4818820ab1ad890040ca4b58cdcb9eL3-R3)
* Updated package references in `Blazor.Heroicons.csproj` to add support for `Microsoft.AspNetCore.Components.Web` version `10.0.*` and removed references for versions `6.0.*` and `7.0.*`. (`src/Blazor.Heroicons/Blazor.Heroicons.csproj` [src/Blazor.Heroicons/Blazor.Heroicons.csprojR27-L34](diffhunk://#diff-093feab2d26d5191666c124bbb68a5e630c628adbacf3f5eb376470071ea78ffR27-L34))

CI/CD workflow updates:

* Updated the `.github/workflows/dotnet.yml` workflow to use .NET 10.0.x, removing 6.0.x and 7.0.x.
* Updated the `.github/workflows/publish.yml` workflow to use .NET 10.0.x instead of 9.0.x.