### PR TITLE
Cache Type.GetType() lookups in Heroicon component

### DIFF
--- a/src/Blazor.Heroicons/Heroicon.razor
+++ b/src/Blazor.Heroicons/Heroicon.razor
@@ -1,3 +1,4 @@
+@using System.Collections.Concurrent
 @inherits HeroiconBase
 @if (_razorComponentType is not null)
 {
@@ -19,6 +20,8 @@ else
     /// </summary>
     [Parameter] public HeroiconType Type { get; set; } = HeroiconType.Outline;
 
+    private static readonly ConcurrentDictionary<string, Type?> _typeCache = new();
+
     private HeroiconType _heroiconType;
     private Type? _razorComponentType;
 
@@ -39,7 +42,8 @@ else
         _heroiconType != Type)
         {
             //find icon based on name and type
-            _razorComponentType = System.Type.GetType($"Blazor.Heroicons.{Type}.{name}", false, true);
+            var key = $"Blazor.Heroicons.{Type}.{name}";
+            _razorComponentType = _typeCache.GetOrAdd(key, k => System.Type.GetType(k, false, true));
             _heroiconType = Type;
         }
     }


### PR DESCRIPTION
## Summary
- Add a `static ConcurrentDictionary<string, Type?>` cache to `Heroicon.razor`
- Avoids repeated reflection lookups when the same icon is used across multiple component instances (e.g., in lists)
- Matches the caching pattern already used in `RandomHeroicon.razor`

## Test plan
- [ ] Verify existing tests pass
- [ ] Render a list with many identical `<Heroicon>` components and confirm correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)