### PR TITLE
Fix tarfile.extractall() deprecation and bump Python to 3.12

### DIFF
--- a/.github/workflows/heroicons.yml
+++ b/.github/workflows/heroicons.yml
@@ -30,7 +30,7 @@ jobs:
         if: ${{ steps.latest_release.outputs.tag != env.current_version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Get latest release
         if: ${{ steps.latest_release.outputs.tag != env.current_version }}

--- a/scripts/get-latest-heroicons.py
+++ b/scripts/get-latest-heroicons.py
@@ -51,7 +51,7 @@ def main():
     print("Extracting tar file...")
     tar = tarfile.open(tar_filename)
     tar.extractall(members=optimized_files(
-        tar, os.path.commonprefix(tar.getnames())), path="tmp")
+        tar, os.path.commonprefix(tar.getnames())), path="tmp", filter="data")
     tar.close()
     os.remove(tar_filename)
 


### PR DESCRIPTION
## Summary
- Add `filter="data"` to `tarfile.extractall()` to address the path-traversal security risk and silence the Python 3.12+ deprecation warning
- Bump CI Python version from 3.10 to 3.12

## Test plan
- [ ] Run `scripts/get-latest-heroicons.py` manually and confirm icons are generated correctly
- [ ] Verify no deprecation warnings in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)