### PR TITLE
Add test step to NuGet publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,16 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
       - name: Restore dependencies
-        run: dotnet restore src/Blazor.Heroicons/Blazor.Heroicons.csproj
+        run: dotnet restore
       - name: Build
-        run: dotnet build src/Blazor.Heroicons/Blazor.Heroicons.csproj --no-restore --configuration Release
+        run: dotnet build --no-restore --configuration Release
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal
       - name: Pack
         run: dotnet pack src/Blazor.Heroicons/Blazor.Heroicons.csproj --no-build --configuration Release -o .
       - name: Publish package to NuGet


### PR DESCRIPTION
## Summary
- Restore and build the full solution (not just the library project) in the publish workflow
- Add a `dotnet test` step before packing to prevent shipping broken packages
- Set up all three .NET SDK versions (8.0, 9.0, 10.0) to match the CI workflow

## Test plan
- [ ] Push a test tag and verify the workflow runs tests before packing
- [ ] Confirm NuGet package is still produced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)