### PR TITLE
Use IReadOnlyDictionary for AdditionalAttributes

### DIFF
--- a/src/Blazor.Heroicons/Heroicon.razor
+++ b/src/Blazor.Heroicons/Heroicon.razor
@@ -2,7 +2,7 @@
 @inherits HeroiconBase
 @if (_razorComponentType is not null)
 {
-    <DynamicComponent Type="_razorComponentType" Parameters="AdditionalAttributes"></DynamicComponent>
+    <DynamicComponent Type="_razorComponentType" Parameters="@(AdditionalAttributes.ToDictionary(k => k.Key, v => v.Value))"></DynamicComponent>
 }
 else
 {

--- a/src/Blazor.Heroicons/HeroiconBase.cs
+++ b/src/Blazor.Heroicons/HeroiconBase.cs
@@ -8,7 +8,7 @@ public abstract class HeroiconBase : ComponentBase
     /// Gets or sets a collection of additional attributes that will be applied to the created element.
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)]
-    public Dictionary<string, object> AdditionalAttributes { get; set; } = new();
+    public IReadOnlyDictionary<string, object> AdditionalAttributes { get; set; } = new Dictionary<string, object>();
 }
 
 /// <summary>

--- a/src/Blazor.Heroicons/RandomHeroicon.razor
+++ b/src/Blazor.Heroicons/RandomHeroicon.razor
@@ -4,7 +4,7 @@
 
 @if (_razorComponentType is not null)
 {
-    <DynamicComponent Type="_razorComponentType" Parameters="AdditionalAttributes"></DynamicComponent>
+    <DynamicComponent Type="_razorComponentType" Parameters="@(AdditionalAttributes.ToDictionary(k => k.Key, v => v.Value))"></DynamicComponent>
 }
 else
 {


### PR DESCRIPTION
## Summary
- Change `AdditionalAttributes` type from `Dictionary<string, object>` to `IReadOnlyDictionary<string, object>` in `HeroiconBase`
- Better communicates intent and aligns with the Blazor convention where the framework internally passes `IReadOnlyDictionary`

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm attribute splatting still works on all icon component types

🤖 Generated with [Claude Code](https://claude.com/claude-code)