### PR TITLE
Remove unnecessary backup file creation in icon generator

### DIFF
--- a/scripts/get-latest-heroicons.py
+++ b/scripts/get-latest-heroicons.py
@@ -131,9 +131,6 @@ def update_readme_heroicons_version(version_tag):
 def update_heroicon_name_class(glob):
 
     filename = "src/Blazor.Heroicons/HeroiconName.cs"
-    backupFilename = filename + ".bak"
-
-    shutil.copyfile(filename, backupFilename)
 
     content = "namespace Blazor.Heroicons;\n"
     content = content + "\n"


### PR DESCRIPTION
## Summary
- Remove the `.bak` file creation in `update_heroicon_name_class()` — the file is fully regenerated each run so the backup is never used

## Test plan
- [ ] Run `scripts/get-latest-heroicons.py` and confirm `HeroiconName.cs` is regenerated correctly
- [ ] Verify no `.bak` file is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)