### PR TITLE
Add explicit demo app build step to CI workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,3 +25,5 @@ jobs:
         run: dotnet build --no-restore
       - name: Test
         run: dotnet test --no-build --verbosity normal
+      - name: Build demo app
+        run: dotnet build src/DemoWebApp/DemoWebApp/DemoWebApp.csproj --no-restore --verbosity normal


### PR DESCRIPTION
## Summary
- Add a dedicated build step for `DemoWebApp` in the CI workflow
- Makes demo app build failures immediately visible rather than hidden in the solution-wide build output

## Test plan
- [ ] Verify CI workflow passes
- [ ] Intentionally break the demo app and confirm the new step catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)