### PR TITLE
Suppress IL2111 trimmer warning for DynamicComponent

### DIFF
--- a/src/Blazor.Heroicons/Blazor.Heroicons.csproj
+++ b/src/Blazor.Heroicons/Blazor.Heroicons.csproj
@@ -15,6 +15,9 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<IsTrimmable>true</IsTrimmable>
+		<!-- IL2111: DynamicComponent.Type setter is called via reflection by the Razor source generator.
+		     All icon types are statically referenced via typeof() in HeroiconRegistry, so trimming is safe. -->
+		<NoWarn>$(NoWarn);IL2111</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<SupportedPlatform Include="browser" />


### PR DESCRIPTION
## Summary
- Add `NoWarn` for IL2111 in the csproj to suppress the false-positive trimmer warning from Razor source generator calling `DynamicComponent.Type.set` via reflection
- All icon types are statically referenced via `typeof()` in `HeroiconRegistry`, so the trimmer will preserve them — the warning is a known Blazor framework false positive
- Build now produces **0 warnings, 0 errors** across all target frameworks

## Test plan
- [x] `dotnet build --no-incremental` produces 0 warnings, 0 errors
- [x] All existing tests pass
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)