### PR TITLE
Cache DynamicComponent parameters to avoid per-render allocation

### DIFF
--- a/src/Blazor.Heroicons/Heroicon.razor
+++ b/src/Blazor.Heroicons/Heroicon.razor
@@ -1,7 +1,7 @@
 @inherits HeroiconBase
 @if (_razorComponentType is not null)
 {
-    <DynamicComponent Type="_razorComponentType" Parameters="@(AdditionalAttributes.ToDictionary(k => k.Key, v => v.Value))"></DynamicComponent>
+    <DynamicComponent Type="_razorComponentType" Parameters="_parameters"></DynamicComponent>
 }
 else
 {
@@ -21,6 +21,8 @@ else
 
     private HeroiconType _heroiconType;
     private Type? _razorComponentType;
+    private IReadOnlyDictionary<string, object>? _lastAttributes;
+    private IDictionary<string, object>? _parameters;
 
     protected override void OnParametersSet()
     {
@@ -42,6 +44,12 @@ else
             var key = $"Blazor.Heroicons.{Type}.{name}";
             _razorComponentType = HeroiconRegistry.Resolve(key);
             _heroiconType = Type;
+        }
+
+        if (_lastAttributes != AdditionalAttributes)
+        {
+            _lastAttributes = AdditionalAttributes;
+            _parameters = AdditionalAttributes.ToDictionary(k => k.Key, v => v.Value);
         }
     }
 

--- a/src/Blazor.Heroicons/RandomHeroicon.razor
+++ b/src/Blazor.Heroicons/RandomHeroicon.razor
@@ -2,7 +2,7 @@
 
 @if (_razorComponentType is not null)
 {
-    <DynamicComponent Type="_razorComponentType" Parameters="@(AdditionalAttributes.ToDictionary(k => k.Key, v => v.Value))"></DynamicComponent>
+    <DynamicComponent Type="_razorComponentType" Parameters="_parameters"></DynamicComponent>
 }
 else
 {
@@ -17,6 +17,8 @@ else
     public HeroiconType Type { get; set; } = HeroiconType.Outline;
     private HeroiconType _heroiconType = HeroiconType.Outline;
     private Type? _razorComponentType;
+    private IReadOnlyDictionary<string, object>? _lastAttributes;
+    private IDictionary<string, object>? _parameters;
 
     /// <summary>
     /// Optional seed for deterministic icon selection. Changing the seed picks a new icon.
@@ -34,6 +36,12 @@ else
             _heroiconType = Type;
             _seed = Seed;
             _razorComponentType = GetRandomIcon(Type, Seed);
+        }
+
+        if (_lastAttributes != AdditionalAttributes)
+        {
+            _lastAttributes = AdditionalAttributes;
+            _parameters = AdditionalAttributes.ToDictionary(k => k.Key, v => v.Value);
         }
     }
 


### PR DESCRIPTION
## Summary
- Cache the `IDictionary<string, object>` passed to `DynamicComponent.Parameters` in `Heroicon` and `RandomHeroicon`
- Only rebuild the dictionary when `AdditionalAttributes` actually changes, instead of calling `.ToDictionary()` inline on every render cycle
- Eliminates unnecessary heap allocation per render for these components

## Test plan
- [x] All 22 existing bunit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)